### PR TITLE
Add Terraform plan upload endpoint

### DIFF
--- a/internal/handlers/plan.go
+++ b/internal/handlers/plan.go
@@ -1,41 +1,73 @@
 package handlers
 
 import (
-    "encoding/json"
-    "net/http"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
 
-    "github.com/gin-gonic/gin"
-    "github.com/yourusername/preflight/internal/models"
-    "github.com/yourusername/preflight/internal/cost"
+	"github.com/gin-gonic/gin"
+	"github.com/yourusername/preflight/internal/cost"
+	"github.com/yourusername/preflight/internal/models"
 )
 
 func AnalysePlan(c *gin.Context) {
-    var plan models.TerraformPlan
-    if err := json.NewDecoder(c.Request.Body).Decode(&plan); err != nil {
-        c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON"})
-        return
-    }
+	var plan models.TerraformPlan
+	if err := json.NewDecoder(c.Request.Body).Decode(&plan); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON"})
+		return
+	}
 
-    var resources []map[string]interface{}
-    var totalCost float64
+	c.JSON(http.StatusOK, analyse(plan))
+}
 
-    for _, rc := range plan.ResourceChanges {
-        // Assume 1 resource per change for now
-        costEstimate := cost.EstimateCost(rc.Type, 1)
-        totalCost += costEstimate
+// UploadPlan handles multipart file uploads of Terraform plan JSON.
+// The uploaded file should be provided under the "file" form field.
+func UploadPlan(c *gin.Context) {
+	file, err := c.FormFile("file")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "plan file required"})
+		return
+	}
 
-        resources = append(resources, map[string]interface{}{
-            "address": rc.Address,
-            "type":    rc.Type,
-            "name":    rc.Name,
-            "actions": rc.Change.Actions,
-            "monthly_cost_estimate": costEstimate,
-        })
-    }
+	var opened multipart.File
+	opened, err = file.Open()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "unable to read file"})
+		return
+	}
+	defer opened.Close()
 
-    c.JSON(http.StatusOK, gin.H{
-        "total_resources": len(resources),
-        "total_monthly_cost_estimate": totalCost,
-        "resources": resources,
-    })
+	var plan models.TerraformPlan
+	if err := json.NewDecoder(opened).Decode(&plan); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid plan file"})
+		return
+	}
+
+	c.JSON(http.StatusOK, analyse(plan))
+}
+
+// analyse generates the cost summary for a Terraform plan.
+func analyse(plan models.TerraformPlan) gin.H {
+	var resources []map[string]interface{}
+	var totalCost float64
+
+	for _, rc := range plan.ResourceChanges {
+		// Assume 1 resource per change for now
+		costEstimate := cost.EstimateCost(rc.Type, 1)
+		totalCost += costEstimate
+
+		resources = append(resources, map[string]interface{}{
+			"address":               rc.Address,
+			"type":                  rc.Type,
+			"name":                  rc.Name,
+			"actions":               rc.Change.Actions,
+			"monthly_cost_estimate": costEstimate,
+		})
+	}
+
+	return gin.H{
+		"total_resources":             len(resources),
+		"total_monthly_cost_estimate": totalCost,
+		"resources":                   resources,
+	}
 }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -1,12 +1,13 @@
 package routes
 
 import (
-    "github.com/gin-gonic/gin"
-    "github.com/yourusername/preflight/internal/handlers"
+	"github.com/gin-gonic/gin"
+	"github.com/yourusername/preflight/internal/handlers"
 )
 
 func RegisterRoutes(r *gin.Engine) {
-    api := r.Group("/api/v1")
-    api.GET("/health", handlers.HealthCheck)
-    api.POST("/plan/analyse", handlers.AnalysePlan)
+	api := r.Group("/api/v1")
+	api.GET("/health", handlers.HealthCheck)
+	api.POST("/plan/analyse", handlers.AnalysePlan)
+	api.POST("/plan/upload", handlers.UploadPlan)
 }


### PR DESCRIPTION
## Summary
- add endpoint to upload a Terraform plan file
- analyze uploaded plan and reuse cost calculation logic

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68864ae68be8832cb1744a5892992e5f