### PR TITLE
Add Postman collection and update upload endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,14 @@ With the server running and the example JSON saved as `plan.json` you can send i
 using `curl`:
 
 ```bash
-curl -X POST \ 
-  -H "Content-Type: application/json" \
-  --data @plan.json \
-  http://localhost:3000/api/v1/plan/analyse
+curl -X POST \
+  -F "file=@plan.json" \
+  http://localhost:3000/api/v1/plan/upload 
 ```
 
 The response includes the number of resources, the total monthly cost estimate
 and a list of each resource with its individual estimated cost.
+
+## Postman Collection
+
+The `postman` directory contains a ready-to-use Postman collection and environment for testing the API's health check and plan upload endpoints.

--- a/postman/PreFlight.postman_collection.json
+++ b/postman/PreFlight.postman_collection.json
@@ -1,0 +1,59 @@
+{
+  "info": {
+    "name": "PreFlight API",
+    "_postman_id": "b9b8e4de-2f2a-4cbe-81ea-7f2a45b95f91",
+    "description": "Collection for testing PreFlight Terraform cost analysis API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Health Check",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/api/v1/health",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "health"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Upload Terraform Plan",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "formdata",
+          "formdata": [
+            {
+              "key": "file",
+              "type": "file",
+              "src": ""
+            }
+          ]
+        },
+        "url": {
+          "raw": "{{base_url}}/api/v1/plan/upload",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "plan",
+            "upload"
+          ]
+        }
+      },
+      "response": []
+    }
+  ]
+}

--- a/postman/PreFlight.postman_environment.json
+++ b/postman/PreFlight.postman_environment.json
@@ -1,0 +1,14 @@
+{
+  "id": "f3f3a3c4-dff6-4af9-a6ad-d2a91d822c14",
+  "name": "PreFlight - Local",
+  "values": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:3000",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2025-07-27T00:00:00Z",
+  "_postman_exported_using": "Postman/10.20.0"
+}


### PR DESCRIPTION
## Summary
- add a Postman collection and environment for the API
- document the new `/api/v1/plan/upload` endpoint

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68864e7a4a78832ca3a8a20ee26ef85d