### PR TITLE
Add result upload endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ curl -X POST \
 The response includes the number of resources, the total monthly cost estimate
 and a list of each resource with its individual estimated cost.
 
+## Uploading analysis results
+
+If you need to store the JSON output from a previous analysis you can POST it
+back to the API:
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  --data @result.json \
+  http://localhost:3000/api/v1/plan/result/upload
+```
+
+The API will write the uploaded JSON to a file under the `results` directory and
+return the path to the saved file.
+
 ## Postman Collection
 
 The `postman` directory contains a ready-to-use Postman collection and environment for testing the API's health check and plan upload endpoints.

--- a/internal/handlers/result.go
+++ b/internal/handlers/result.go
@@ -1,0 +1,38 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// UploadResult accepts a JSON cost analysis result and saves it to disk.
+func UploadResult(c *gin.Context) {
+	var result map[string]interface{}
+	if err := c.ShouldBindJSON(&result); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid JSON"})
+		return
+	}
+
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "unable to marshal JSON"})
+		return
+	}
+
+	if err := os.MkdirAll("results", 0755); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "unable to create results directory"})
+		return
+	}
+
+	filename := "results/result-" + time.Now().Format("20060102150405") + ".json"
+	if err := os.WriteFile(filename, data, 0644); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "unable to save result"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "saved", "path": filename})
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -10,4 +10,5 @@ func RegisterRoutes(r *gin.Engine) {
 	api.GET("/health", handlers.HealthCheck)
 	api.POST("/plan/analyse", handlers.AnalysePlan)
 	api.POST("/plan/upload", handlers.UploadPlan)
+	api.POST("/plan/result/upload", handlers.UploadResult)
 }

--- a/postman/PreFlight.postman_collection.json
+++ b/postman/PreFlight.postman_collection.json
@@ -54,6 +54,31 @@
         }
       },
       "response": []
+    },
+    {
+      "name": "Upload Analysis Result",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": ""
+        },
+        "url": {
+          "raw": "{{base_url}}/api/v1/plan/result/upload",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "v1",
+            "plan",
+            "result",
+            "upload"
+          ]
+        }
+      },
+      "response": []
     }
   ]
 }


### PR DESCRIPTION
## Summary
- implement `UploadResult` handler that stores analysis JSON
- register new route for analysis result uploads
- document result upload endpoint
- extend Postman collection with the new request

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6886503bad14832cad87d40d7da3166d