### PR TITLE
Support JSON body upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,24 @@ then posting `plan.json` to the API.
 
 ## Analysing a plan
 
-With the server running and the example JSON saved as `plan.json` you can send it
-using `curl`:
+With the server running and the example JSON saved as `plan.json` you can send
+it to the `/plan/upload` endpoint either as a file upload or directly as JSON.
+
+### Uploading a file
 
 ```bash
 curl -X POST \
   -F "file=@plan.json" \
-  http://localhost:3000/api/v1/plan/upload 
+  http://localhost:3000/api/v1/plan/upload
+```
+
+### Sending raw JSON
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  --data @plan.json \
+  http://localhost:3000/api/v1/plan/upload
 ```
 
 The response includes the number of resources, the total monthly cost estimate


### PR DESCRIPTION
## Summary
- allow `/plan/upload` to accept JSON in the request body
- document both file upload and JSON options in README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688653453b90832c8173e2310006029f