### PR TITLE
Fix lambda runtime

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Build lambda zip
         run: |
           mkdir -p build
-          GOOS=linux GOARCH=amd64 go build -o build/preflight ./cmd
-          cd build && zip preflight.zip preflight && cd ..
+          GOOS=linux GOARCH=amd64 go build -o build/bootstrap ./cmd
+          cd build && zip preflight.zip bootstrap && cd ..
       - name: Terraform Init
         run: terraform -chdir=infra init
       - name: Terraform Apply

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -27,8 +27,8 @@ resource "aws_iam_role_policy_attachment" "lambda_basic" {
 resource "aws_lambda_function" "api" {
   function_name = var.app_name
   role          = aws_iam_role.lambda.arn
-  runtime       = "go1.x"
-  handler       = "main"
+  runtime       = "provided.al2"
+  handler       = "bootstrap"
 
   filename         = "${path.module}/../build/${var.app_name}.zip"
   source_code_hash = filebase64sha256("${path.module}/../build/${var.app_name}.zip")
@@ -46,9 +46,9 @@ resource "aws_apigatewayv2_api" "http" {
 }
 
 resource "aws_apigatewayv2_integration" "lambda" {
-  api_id             = aws_apigatewayv2_api.http.id
-  integration_type   = "AWS_PROXY"
-  integration_uri    = aws_lambda_function.api.invoke_arn
+  api_id                 = aws_apigatewayv2_api.http.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.api.invoke_arn
   payload_format_version = "2.0"
 }
 


### PR DESCRIPTION
## Summary
- update the Lambda runtime to the supported `provided.al2`
- build the AWS Lambda zip with a `bootstrap` binary

## Testing
- `go test ./...`
- `terraform -chdir=infra fmt -check`
- `terraform -chdir=infra init -backend=false` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_688674a109c0832c93ed5ea4817e4ed7