### PR TITLE
Configure Terraform S3 backend

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -1,17 +1,14 @@
-name: Deploy Lambda
+name: Deploy Infra
 
 on:
   workflow_dispatch:
   push:
     paths:
-      - 'cmd/**'
-      - 'internal/**'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/deploy.yml'
+      - 'infra/**'
+      - '.github/workflows/infra.yml'
 
 jobs:
-  deploy:
+  terraform:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -23,12 +20,19 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE }}
           aws-region: ${{ secrets.AWS_REGION }}
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.6.6
       - name: Build lambda zip
         run: |
           mkdir -p build
           GOOS=linux GOARCH=amd64 go build -o build/bootstrap ./cmd
           cd build && zip preflight.zip bootstrap && cd ..
-      - name: Update Lambda code
-        run: aws lambda update-function-code --function-name ${APP_NAME} --zip-file fileb://build/preflight.zip
+      - name: Terraform Init
+        run: terraform -chdir=infra init -backend-config="bucket=${STATE_BUCKET}" -backend-config="key=${APP_NAME}/terraform.tfstate" -backend-config="region=${AWS_REGION}"
         env:
+          STATE_BUCKET: ${{ secrets.STATE_BUCKET }}
           APP_NAME: ${{ secrets.APP_NAME }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+      - name: Terraform Apply
+        run: terraform -chdir=infra apply -auto-approve

--- a/README.md
+++ b/README.md
@@ -88,12 +88,19 @@ The `postman` directory contains a ready-to-use Postman collection and environme
 
 ## GitHub Actions Deployment
 
-The repository contains a `Deploy` workflow that packages the API as an AWS Lambda function and applies the Terraform in `infra/`.
-To run it you must configure the following secrets in your GitHub repository:
+Two workflows manage the AWS resources:
+
+* **Deploy Lambda** – builds the application and updates the Lambda function code.
+* **Deploy Infra** – applies the Terraform in `infra/`.
+
+Both workflows require these secrets in your GitHub repository:
 
 - `AWS_REGION` – AWS region where the Lambda and API Gateway will be created
 - `APP_NAME` – name for the Lambda function and API Gateway resources
 - `AWS_DEPLOY_ROLE` – ARN of an IAM role that GitHub Actions is allowed to assume
+- `STATE_BUCKET` – name of the S3 bucket where the Terraform state will be stored (only required for **Deploy Infra**)
+
+The bucket specified by `STATE_BUCKET` must exist before running the **Deploy Infra** workflow.
 
 ### Creating the deploy role
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -38,6 +38,10 @@ resource "aws_lambda_function" "api" {
       PORT = "3000"
     }
   }
+
+  lifecycle {
+    ignore_changes = [filename, source_code_hash]
+  }
 }
 
 resource "aws_apigatewayv2_api" "http" {

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,4 +1,6 @@
 terraform {
+  backend "s3" {}
+
   required_version = ">= 1.5"
   required_providers {
     aws = {


### PR DESCRIPTION
## Summary
- configure Terraform to use an S3 backend
- initialize the backend in the deployment workflow
- document the new STATE_BUCKET secret
- split lambda and Terraform deployments into separate workflows

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688681d30954832c91b7f5889303ea18