### PR TITLE
Update Postman environment remote URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,10 @@ return the path to the saved file.
 
 ## Postman Collection
 
-The `postman` directory contains a ready-to-use Postman collection and environment for testing the API's health check and plan upload endpoints.
+The `postman` directory contains a ready-to-use Postman collection with separate environments for local and dev testing:
+
+* `PreFlight.postman_environment.json` – points to a local API running on `http://localhost:3000`
+* `PreFlight.dev.postman_environment.json` – points to the remote dev API
 
 ## GitHub Actions Deployment
 

--- a/postman/PreFlight.dev.postman_environment.json
+++ b/postman/PreFlight.dev.postman_environment.json
@@ -1,0 +1,14 @@
+{
+  "id": "f3f3a3c4-dff6-4af9-a6ad-d2a91d822c14",
+  "name": "PreFlight - Dev",
+  "values": [
+    {
+      "key": "base_url",
+      "value": "https://qovla75eo8.execute-api.eu-west-2.amazonaws.com/",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2025-07-27T00:00:00Z",
+  "_postman_exported_using": "Postman/10.20.0"
+}


### PR DESCRIPTION
## Summary
- switch Postman environment to point at the remote API URL
- keep a separate local Postman environment

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68869921cfd0832c9ddd4cd779177078