### PR TITLE
Add initial unit tests

### DIFF
--- a/internal/cost/calculate_test.go
+++ b/internal/cost/calculate_test.go
@@ -1,0 +1,17 @@
+package cost
+
+import "testing"
+
+func TestEstimateCostKnown(t *testing.T) {
+	got := EstimateCost("aws_instance", 2)
+	if got != 50.0 {
+		t.Errorf("expected 50.0, got %v", got)
+	}
+}
+
+func TestEstimateCostUnknown(t *testing.T) {
+	got := EstimateCost("unknown_resource", 1)
+	if got != 0.0 {
+		t.Errorf("expected 0.0, got %v", got)
+	}
+}

--- a/internal/handlers/plan_test.go
+++ b/internal/handlers/plan_test.go
@@ -1,0 +1,48 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+const samplePlan = `{
+  "resource_changes": [
+    {"address":"aws_instance.example","type":"aws_instance","name":"example","change":{"actions":["create"]}},
+    {"address":"aws_s3_bucket.data","type":"aws_s3_bucket","name":"data","change":{"actions":["create"]}}
+  ]
+}`
+
+func TestAnalysePlanHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.POST("/analyse", AnalysePlan)
+
+	req := httptest.NewRequest(http.MethodPost, "/analyse", strings.NewReader(samplePlan))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	var resp struct {
+		TotalResources int     `json:"total_resources"`
+		TotalCost      float64 `json:"total_monthly_cost_estimate"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.TotalResources != 2 {
+		t.Errorf("expected 2 resources, got %d", resp.TotalResources)
+	}
+	if resp.TotalCost != 30.0 {
+		t.Errorf("expected cost 30.0, got %v", resp.TotalCost)
+	}
+}

--- a/internal/models/terraform_test.go
+++ b/internal/models/terraform_test.go
@@ -1,0 +1,36 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+const samplePlan = `{
+  "resource_changes": [
+    {
+      "address": "aws_instance.example",
+      "type": "aws_instance",
+      "name": "example",
+      "change": {"actions": ["create"]}
+    },
+    {
+      "address": "aws_s3_bucket.data",
+      "type": "aws_s3_bucket",
+      "name": "data",
+      "change": {"actions": ["create"]}
+    }
+  ]
+}`
+
+func TestTerraformPlanUnmarshal(t *testing.T) {
+	var p TerraformPlan
+	if err := json.Unmarshal([]byte(samplePlan), &p); err != nil {
+		t.Fatalf("failed to unmarshal plan: %v", err)
+	}
+	if len(p.ResourceChanges) != 2 {
+		t.Fatalf("expected 2 resource changes, got %d", len(p.ResourceChanges))
+	}
+	if p.ResourceChanges[0].Address != "aws_instance.example" {
+		t.Errorf("unexpected first address: %s", p.ResourceChanges[0].Address)
+	}
+}


### PR DESCRIPTION
## Summary
- add cost calculation tests
- add plan parsing tests
- add handler tests for plan analysis

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68879af965a0832cb1c5ac9a80c5cd94