### PR TITLE
Fix lambda build for glibc

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Build lambda zip
         run: |
           mkdir -p build
-          GOOS=linux GOARCH=amd64 go build -o build/bootstrap ./cmd
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/bootstrap ./cmd
           cd build && zip preflight-api.zip bootstrap && cd ..
       - name: Update Lambda code
         run: aws lambda update-function-code --function-name preflight-api --zip-file fileb://build/preflight-api.zip

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build lambda zip
         run: |
           mkdir -p build
-          GOOS=linux GOARCH=amd64 go build -o build/bootstrap ./cmd
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/bootstrap ./cmd
           cd build && zip preflight-api.zip bootstrap && cd ..
       - name: Terraform Init
         run: terraform -chdir=infra init -backend-config="bucket=${STATE_BUCKET}" -backend-config="key=preflight-api/terraform.tfstate" -backend-config="region=eu-west-2"

--- a/README.md
+++ b/README.md
@@ -32,9 +32,17 @@ go build -o preflight ./cmd
 ./preflight
 ```
 
-To run it as a Lambda function instead, package the binary and apply the
-Terraform configuration in `infra/` which creates the Lambda and API Gateway
-resources.
+To run it as a Lambda function instead, build a Linux binary with `CGO_ENABLED=0`
+and package it for the custom runtime:
+
+```bash
+mkdir -p build
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/bootstrap ./cmd
+cd build && zip preflight-api.zip bootstrap && cd ..
+```
+
+Then apply the Terraform configuration in `infra/` which creates the Lambda and
+API Gateway resources.
 
 ## Terraform plan JSON example
 


### PR DESCRIPTION
## Summary
- compile with CGO disabled for AWS Lambda builds
- document Lambda build commands

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6887cbda8b7c832c9326049b7d8f48f2