### PR TITLE
Fix Lambda path handling

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,8 +34,8 @@ func main() {
 
 	// If running inside AWS Lambda, use the Lambda handler
 	if os.Getenv("AWS_LAMBDA_FUNCTION_NAME") != "" {
-		ginLambda := ginadapter.New(r)
-		lambda.Start(ginLambda.Proxy)
+		ginLambda := ginadapter.NewV2(r)
+		lambda.Start(ginLambda.ProxyWithContext)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- use the APIGateway V2 gin adapter when running on Lambda

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6887da81b134832c8b069245cdbcfc0a